### PR TITLE
Avoid reference mismatch

### DIFF
--- a/src/Centipede/Crawler.php
+++ b/src/Centipede/Crawler.php
@@ -22,19 +22,21 @@ class Crawler
     {
         $urls = [$this->baseUrl];
 
-        return $this->doCrawl(
+        $this->doCrawl(
             $this->baseUrl,
             $this->request($this->baseUrl, $callable),
             $this->depth,
             $callable,
             $urls
         );
+
+        return $urls;
     }
 
     private function doCrawl($url, DomCrawler $crawler, $depth, callable $callable = null, array &$urls = [])
     {
         if (0 === $depth) {
-            return $urls;
+            return;
         }
 
         foreach ($crawler->filter('a') as $node) {
@@ -52,8 +54,6 @@ class Crawler
                 $urls[] = $href;
             }
         }
-
-        return $urls;
     }
 
     private function request($url, callable $callable = null)


### PR DESCRIPTION
Returning the array not by reference is forcing PHP to copy the Zval because the variable is a reference in the method. This change avoids copying the array for each call to `doCrawl`. See http://jpauli.github.io/2014/06/27/references-mismatch.html for details about what reference mismatches are.
