### PR TITLE
Allow PHP 7.X usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "~5.4",
+        "php": ">=5.4",
         "guzzlehttp/guzzle": "~5.3"
     },
     "require-dev": {


### PR DESCRIPTION
This allows for PHP 7.X usage by replacing the Composer tilde operator (which allows >= 5.4 < 6.0.0) by the superior or equal one.