### PR TITLE
Prevent the check of HTML5 <a> tags with a tel protocol

### DIFF
--- a/src/Centipede/Checker/HostChecker.php
+++ b/src/Centipede/Checker/HostChecker.php
@@ -13,7 +13,7 @@ class HostChecker implements CheckerInterface
 
     public function isCrawlable($url)
     {
-        if (empty($url)) {
+        if (empty($url) || preg_match('/^tel:.*/i', $url)) {
             return false;
         }
 


### PR DESCRIPTION
When checking a href which references a phone number (for instance `<a href="tel:+33102030405">+33102030405</a>`, Guzzle is throwing the error:

> [GuzzleHttp\Exception\ConnectException]  
> cURL error 6: Couldn't resolve host name 

This ensures phone numbers in `<a>` tags are not parsed.
