### PR TITLE
Ensures URLs starting with a double slash are handled correctly

### DIFF
--- a/src/Centipede/Filter/UrlFilter.php
+++ b/src/Centipede/Filter/UrlFilter.php
@@ -19,7 +19,7 @@ class UrlFilter implements FilterInterface
             $value = substr($value, 0, $position);
         }
 
-        if (null !== parse_url($value, PHP_URL_SCHEME)) {
+        if (null !== parse_url($value, PHP_URL_SCHEME) || preg_match('/^\/\/.*/', $value)) {
             return $value;
         }
 


### PR DESCRIPTION
According to [RFC 3986](http://tools.ietf.org/html/rfc3986#section-4.2):

> A relative reference that begins with two slash characters is termed a network-path reference

Thus, there may be URLs showing up as `//github.com`, which would set the appropriate protocol according to the current scheme, thus redirecting to `https//github.com` for instance if the current page is using HTTPS.

This ensures that values starting with a double slash are not concatenated to the base URL.